### PR TITLE
CC-9565: Add support for casting stringified UUIDs to uuid upon insert/update/upsert in PostgreSQL

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -311,14 +311,69 @@ public interface DatabaseDialect extends ConnectionProvider {
   /**
    * Build the INSERT prepared statement expression for the given table and its columns.
    *
+   * <p>This method is only called by the default implementation of
+   * {@link #buildInsertStatement(TableId, Collection, Collection, TableDefinition)}, since
+   * many dialects implement this variant of the method. However, overriding
+   * {@link #buildInsertStatement(TableId, Collection, Collection, TableDefinition)} is suggested.
+   *
    * @param table         the identifier of the table; may not be null
    * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
    *                      but may be empty
    * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
    *                      be empty
    * @return the INSERT statement; may not be null
+   * @deprecated use {@link #buildInsertStatement(TableId, Collection, Collection, TableDefinition)}
    */
+  @Deprecated
   String buildInsertStatement(
+      TableId table,
+      Collection<ColumnId> keyColumns,
+      Collection<ColumnId> nonKeyColumns
+  );
+
+  /**
+   * Build the INSERT prepared statement expression for the given table and its columns.
+   *
+   * <p>By default this method calls
+   * {@link #buildInsertStatement(TableId, Collection, Collection)} to maintain backward
+   * compatibility with older versions. Subclasses that override this method do not need to
+   * override {@link #buildInsertStatement(TableId, Collection, Collection)}.
+   *
+   * @param table         the identifier of the table; may not be null
+   * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
+   *                      but may be empty
+   * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
+   *                      be empty
+   * @param definition    the table definition; may be null if unknown
+   * @return the INSERT statement; may not be null
+   */
+  default String buildInsertStatement(
+          TableId table,
+          Collection<ColumnId> keyColumns,
+          Collection<ColumnId> nonKeyColumns,
+          TableDefinition definition
+  ) {
+    return buildInsertStatement(table, keyColumns, nonKeyColumns);
+  }
+
+  /**
+   * Build the UPDATE prepared statement expression for the given table and its columns. Variables
+   * for each key column should also appear in the WHERE clause of the statement.
+   *
+   * <p>This method is only called by the default implementation of
+   * {@link #buildUpdateStatement(TableId, Collection, Collection, TableDefinition)}, since
+   * many dialects implement this variant of the method. However, overriding
+   * {@link #buildUpdateStatement(TableId, Collection, Collection, TableDefinition)} is suggested.
+   *
+   * @param table         the identifier of the table; may not be null
+   * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
+   *                      but may be empty
+   * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
+   *                      be empty
+   * @return the UPDATE statement; may not be null
+   * @deprecated use {@link #buildUpdateStatement(TableId, Collection, Collection, TableDefinition)}
+   */
+  String buildUpdateStatement(
       TableId table,
       Collection<ColumnId> keyColumns,
       Collection<ColumnId> nonKeyColumns
@@ -328,14 +383,49 @@ public interface DatabaseDialect extends ConnectionProvider {
    * Build the UPDATE prepared statement expression for the given table and its columns. Variables
    * for each key column should also appear in the WHERE clause of the statement.
    *
+   * <p>By default this method calls
+   * {@link #buildUpdateStatement(TableId, Collection, Collection)} to maintain backward
+   * compatibility with older versions. Subclasses that override this method do not need to
+   * override {@link #buildUpdateStatement(TableId, Collection, Collection)}.
+   *
    * @param table         the identifier of the table; may not be null
    * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
    *                      but may be empty
    * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
    *                      be empty
+   * @param definition    the table definition; may be null if unknown
    * @return the UPDATE statement; may not be null
    */
-  String buildUpdateStatement(
+  default String buildUpdateStatement(
+          TableId table,
+          Collection<ColumnId> keyColumns,
+          Collection<ColumnId> nonKeyColumns,
+          TableDefinition definition
+  ) {
+    return buildUpdateStatement(table, keyColumns, nonKeyColumns);
+  }
+
+  /**
+   * Build the UPSERT or MERGE prepared statement expression to either insert a new record into the
+   * given table or update an existing record in that table Variables for each key column should
+   * also appear in the WHERE clause of the statement.
+   *
+   * <p>This method is only called by the default implementation of
+   * {@link #buildUpsertQueryStatement(TableId, Collection, Collection, TableDefinition)}, since
+   * many dialects implement this variant of the method. However, overriding
+   * {@link #buildUpsertQueryStatement(TableId, Collection, Collection, TableDefinition)}
+   * is suggested.
+   *
+   * @param table         the identifier of the table; may not be null
+   * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
+   *                      but may be empty
+   * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
+   *                      be empty
+   * @return the upsert/merge statement; may not be null
+   * @throws UnsupportedOperationException if the dialect does not support upserts
+   * @deprecated use {@link #buildUpsertQueryStatement(TableId, Collection, Collection)}
+   */
+  String buildUpsertQueryStatement(
       TableId table,
       Collection<ColumnId> keyColumns,
       Collection<ColumnId> nonKeyColumns
@@ -346,19 +436,28 @@ public interface DatabaseDialect extends ConnectionProvider {
    * given table or update an existing record in that table Variables for each key column should
    * also appear in the WHERE clause of the statement.
    *
+   * <p>By default this method calls
+   * {@link #buildUpsertQueryStatement(TableId, Collection, Collection)} to maintain backward
+   * compatibility with older versions. Subclasses that override this method do not need to
+   * override {@link #buildUpsertQueryStatement(TableId, Collection, Collection)}.
+   *
    * @param table         the identifier of the table; may not be null
    * @param keyColumns    the identifiers of the columns in the primary/unique key; may not be null
    *                      but may be empty
    * @param nonKeyColumns the identifiers of the other columns in the table; may not be null but may
    *                      be empty
+   * @param definition    the table definition; may be null if unknown
    * @return the upsert/merge statement; may not be null
    * @throws UnsupportedOperationException if the dialect does not support upserts
    */
-  String buildUpsertQueryStatement(
-      TableId table,
-      Collection<ColumnId> keyColumns,
-      Collection<ColumnId> nonKeyColumns
-  );
+  default String buildUpsertQueryStatement(
+          TableId table,
+          Collection<ColumnId> keyColumns,
+          Collection<ColumnId> nonKeyColumns,
+          TableDefinition definition
+  ) {
+    return buildUpsertQueryStatement(table, keyColumns, nonKeyColumns);
+  }
 
   /**
    * Build the DELETE prepared statement expression for the given table and its columns. Variables

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -321,13 +321,14 @@ public class BufferedRecords {
     }
   }
 
-  private String getInsertSql() {
+  private String getInsertSql() throws SQLException {
     switch (config.insertMode) {
       case INSERT:
         return dbDialect.buildInsertStatement(
             tableId,
             asColumns(fieldsMetadata.keyFieldNames),
-            asColumns(fieldsMetadata.nonKeyFieldNames)
+            asColumns(fieldsMetadata.nonKeyFieldNames),
+            dbStructure.tableDefinition(connection, tableId)
         );
       case UPSERT:
         if (fieldsMetadata.keyFieldNames.isEmpty()) {
@@ -342,14 +343,16 @@ public class BufferedRecords {
             return dbDialect.buildInsertStatement(
                     tableId,
                     asColumns(fieldsMetadata.keyFieldNames),
-                    asColumns(fieldsMetadata.nonKeyFieldNames)
+                    asColumns(fieldsMetadata.nonKeyFieldNames),
+                    dbStructure.tableDefinition(connection, tableId)
             );
           }
           else {
             return dbDialect.buildInsertStatement(
                     tableId,
                     asColumns(fieldsMetadata.keyFieldNames),
-                    asColumns(fieldsMetadata.nonKeyFieldNames)
+                    asColumns(fieldsMetadata.nonKeyFieldNames),
+                    dbStructure.tableDefinition(connection, tableId)
             );
           }
         } catch (UnsupportedOperationException e) {
@@ -363,7 +366,8 @@ public class BufferedRecords {
         return dbDialect.buildUpdateStatement(
             tableId,
             asColumns(fieldsMetadata.keyFieldNames),
-            asColumns(fieldsMetadata.nonKeyFieldNames)
+            asColumns(fieldsMetadata.nonKeyFieldNames),
+            dbStructure.tableDefinition(connection, tableId)
         );
       default:
         throw new ConnectException("Invalid insert mode");

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -81,6 +81,27 @@ public class DbStructure {
   }
 
   /**
+   * Get the definition for the table with the given ID. This returns a cached definition if
+   * there is one; otherwise, it reads the definition from the database
+   *
+   * @param connection the connection that may be used to fetch the table definition if not
+   *                   already known; may not be null
+   * @param tableId    the ID of the table; may not be null
+   * @return the table definition; or null if the table does not exist
+   * @throws SQLException if there is an error getting the definition from the database
+   */
+  public TableDefinition tableDefinition(
+          Connection connection,
+          TableId tableId
+  ) throws SQLException {
+    TableDefinition defn = tableDefns.get(connection, tableId);
+    if (defn != null) {
+      return defn;
+    }
+    return tableDefns.refresh(connection, tableId);
+  }
+
+  /**
    * @throws SQLException if CREATE failed
    */
   void create(

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -15,7 +15,10 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.sql.JDBCType;
 import java.sql.Types;
+
+import io.confluent.connect.jdbc.util.*;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -24,10 +27,10 @@ import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-
-import io.confluent.connect.jdbc.util.QuoteMethod;
-import io.confluent.connect.jdbc.util.TableId;
+import java.util.List;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 
@@ -63,6 +66,7 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   public void testCustomColumnConverters() {
     assertColumnConverter(Types.OTHER, PostgreSqlDatabaseDialect.JSON_TYPE_NAME, Schema.STRING_SCHEMA, String.class);
     assertColumnConverter(Types.OTHER, PostgreSqlDatabaseDialect.JSONB_TYPE_NAME, Schema.STRING_SCHEMA, String.class);
+    assertColumnConverter(Types.OTHER, PostgreSqlDatabaseDialect.UUID_TYPE_NAME, Schema.STRING_SCHEMA, UUID.class);
   }
 
   @Test
@@ -172,14 +176,66 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
   }
 
   @Test
+  public void shouldBuildInsertStatement() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnB").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnC").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnD").type("varchar", JDBCType.VARCHAR, String.class);
+    TableDefinition tableDefn = builder.build();
+    assertEquals(
+            "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
+                    "\"columnC\",\"columnD\") VALUES (?,?,?,?,?,?)",
+            dialect.buildInsertStatement(tableId, pkColumns, columnsAtoD, tableDefn)
+    );
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+            "INSERT INTO myTable (id1,id2,columnA,columnB," +
+                    "columnC,columnD) VALUES (?,?,?,?,?,?)",
+            dialect.buildInsertStatement(tableId, pkColumns, columnsAtoD, tableDefn)
+    );
+
+    builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
+    builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
+    tableDefn = builder.build();
+    List<ColumnId> nonPkColumns = new ArrayList<>();
+    nonPkColumns.add(new ColumnId(tableId, "columnA"));
+    nonPkColumns.add(new ColumnId(tableId, "uuidColumn"));
+    nonPkColumns.add(new ColumnId(tableId, "dateColumn"));
+    assertEquals(
+            "INSERT INTO myTable (" +
+                    "id1,id2,columnA,uuidColumn,dateColumn" +
+                    ") VALUES (?,?,?,?::uuid,?)",
+            dialect.buildInsertStatement(tableId, pkColumns, nonPkColumns, tableDefn)
+    );
+  }
+
+  @Test
   public void shouldBuildUpsertStatement() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnB").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnC").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("columnD").type("varchar", JDBCType.VARCHAR, String.class);
+    TableDefinition tableDefn = builder.build();
     assertEquals(
         "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
         "\"columnC\",\"columnD\") VALUES (?,?,?,?,?,?) ON CONFLICT (\"id1\"," +
         "\"id2\") DO UPDATE SET \"columnA\"=EXCLUDED" +
         ".\"columnA\",\"columnB\"=EXCLUDED.\"columnB\",\"columnC\"=EXCLUDED" +
         ".\"columnC\",\"columnD\"=EXCLUDED.\"columnD\"",
-        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD, tableDefn)
     );
 
     quoteIdentfiiers = QuoteMethod.NEVER;
@@ -191,8 +247,48 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         "id2) DO UPDATE SET columnA=EXCLUDED" +
         ".columnA,columnB=EXCLUDED.columnB,columnC=EXCLUDED" +
         ".columnC,columnD=EXCLUDED.columnD",
-        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD, tableDefn)
     );
+
+    builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
+    builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
+    tableDefn = builder.build();
+    List<ColumnId> nonPkColumns = new ArrayList<>();
+    nonPkColumns.add(new ColumnId(tableId, "columnA"));
+    nonPkColumns.add(new ColumnId(tableId, "uuidColumn"));
+    nonPkColumns.add(new ColumnId(tableId, "dateColumn"));
+    assertEquals(
+            "INSERT INTO myTable (" +
+                    "id1,id2,columnA,uuidColumn,dateColumn" +
+                    ") VALUES (?,?,?,?::uuid,?) ON CONFLICT (id1," +
+                    "id2) DO UPDATE SET " +
+                    "columnA=EXCLUDED.columnA," +
+                    "uuidColumn=EXCLUDED.uuidColumn," +
+                    "dateColumn=EXCLUDED.dateColumn",
+            dialect.buildUpsertQueryStatement(tableId, pkColumns, nonPkColumns, tableDefn)
+    );
+  }
+
+  @Test
+  public void shouldComputeValueTypeCast() {
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("myTable");
+    builder.withColumn("id1").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("id2").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("columnA").type("varchar", JDBCType.VARCHAR, Integer.class);
+    builder.withColumn("uuidColumn").type("uuid", JDBCType.OTHER, UUID.class);
+    builder.withColumn("dateColumn").type("date", JDBCType.DATE, java.sql.Date.class);
+    TableDefinition tableDefn = builder.build();
+    ColumnId uuidColumn = tableDefn.definitionForColumn("uuidColumn").id();
+    ColumnId dateColumn = tableDefn.definitionForColumn("dateColumn").id();
+    assertEquals("", dialect.valueTypeCast(tableDefn, columnPK1));
+    assertEquals("", dialect.valueTypeCast(tableDefn, columnPK2));
+    assertEquals("", dialect.valueTypeCast(tableDefn, columnA));
+    assertEquals("::uuid", dialect.valueTypeCast(tableDefn, uuidColumn));
+    assertEquals("", dialect.valueTypeCast(tableDefn, dateColumn));
   }
 
   @Test
@@ -238,7 +334,13 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
 
   @Test
   public void upsert() {
-    TableId customer = tableId("Customer");
+    TableDefinitionBuilder builder = new TableDefinitionBuilder().withTable("Customer");
+    builder.withColumn("id").type("int", JDBCType.INTEGER, Integer.class);
+    builder.withColumn("name").type("varchar", JDBCType.VARCHAR, String.class);
+    builder.withColumn("salary").type("real", JDBCType.FLOAT, String.class);
+    builder.withColumn("address").type("varchar", JDBCType.VARCHAR, String.class);
+    TableDefinition tableDefn = builder.build();
+    TableId customer = tableDefn.id();
     assertEquals(
         "INSERT INTO \"Customer\" (\"id\",\"name\",\"salary\",\"address\") " +
          "VALUES (?,?,?,?) ON CONFLICT (\"id\") DO UPDATE SET \"name\"=EXCLUDED.\"name\"," +
@@ -246,7 +348,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         dialect.buildUpsertQueryStatement(
             customer,
             columns(customer, "id"),
-            columns(customer, "name", "salary", "address")
+            columns(customer, "name", "salary", "address"),
+            tableDefn
         )
     );
 
@@ -256,7 +359,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
             dialect.buildUpsertQueryStatement(
                     customer,
                     columns(customer, "id", "name", "salary", "address"),
-                    columns(customer)
+                    columns(customer),
+                    tableDefn
             )
     );
 
@@ -270,7 +374,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         dialect.buildUpsertQueryStatement(
             customer,
             columns(customer, "id"),
-            columns(customer, "name", "salary", "address")
+            columns(customer, "name", "salary", "address"),
+            tableDefn
         )
     );
 
@@ -280,7 +385,8 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
             dialect.buildUpsertQueryStatement(
                     customer,
                     columns(customer, "id", "name", "salary", "address"),
-                    columns(customer)
+                    columns(customer),
+                    tableDefn
             )
     );
   }

--- a/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/integration/PostgresDatatypeIT.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.sink.integration;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import io.confluent.connect.jdbc.sink.JdbcSinkTask;
+import io.zonky.test.db.postgres.junit.EmbeddedPostgresRules;
+import io.zonky.test.db.postgres.junit.SingleInstancePostgresRule;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Integration tests for writing to Postgres with UUID columns.
+ */
+@Category(IntegrationTest.class)
+public class PostgresDatatypeIT {
+
+    private static Logger log = LoggerFactory.getLogger(PostgresDatatypeIT.class);
+
+    @Rule
+    public SingleInstancePostgresRule pg = EmbeddedPostgresRules.singleInstance();
+
+    private Map<String, String> props;
+    private String tableName;
+    private JdbcSinkTask task;
+
+    @Before
+    public void before() {
+        tableName = "test";
+        props = new HashMap<>();
+        String jdbcURL = String
+                .format("jdbc:postgresql://localhost:%s/postgres", pg.getEmbeddedPostgres().getPort());
+        props.put(JdbcSinkConfig.CONNECTION_URL, jdbcURL);
+        props.put(JdbcSinkConfig.CONNECTION_USER, "postgres");
+        props.put("pk.mode", "none");
+        props.put("topics", tableName);
+    }
+
+    @After
+    public void after() throws SQLException {
+        stopTask();
+        try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+            try (Statement s = c.createStatement()) {
+                s.execute("DROP TABLE IF EXISTS " + tableName);
+            }
+        }
+        log.info("Dropped table");
+    }
+
+    @Test
+    public void testWriteToTableWithUuidColumn() throws SQLException {
+        createTableWithUuidColumns();
+        startTask();
+        final Schema schema = SchemaBuilder.struct().name("com.example.Person")
+                .field("firstname", Schema.STRING_SCHEMA)
+                .field("lastname", Schema.STRING_SCHEMA)
+                .field("jsonid", Schema.STRING_SCHEMA)
+                .field("userid", Schema.STRING_SCHEMA)
+                .build();
+        UUID uuid = UUID.randomUUID();
+        String jsonid = "5";
+        final Struct struct = new Struct(schema)
+                .put("firstname", "Christina")
+                .put("lastname", "Brams")
+                .put("jsonid", jsonid)
+                .put("userid", uuid.toString());
+        task.put(Collections.singleton(new SinkRecord(tableName, 1, null, null, schema, struct, 1)));
+        try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+            try (Statement s = c.createStatement()) {
+                try (ResultSet rs = s.executeQuery("SELECT * FROM " + tableName)) {
+                    assertTrue(rs.next());
+                    assertEquals(struct.getString("firstname"), rs.getString("firstname"));
+                    assertEquals(struct.getString("lastname"), rs.getString("lastname"));
+                    assertEquals(struct.getString("jsonid"), rs.getString("jsonid"));
+                    assertEquals(struct.getString("userid"), rs.getString("userid"));
+                }
+            }
+        }
+    }
+
+    private void createTableWithUuidColumns() throws SQLException {
+        log.info("Creating table {} with UUID column", tableName);
+        try (Connection c = pg.getEmbeddedPostgres().getPostgresDatabase().getConnection()) {
+            c.setAutoCommit(false);
+            try (Statement s = c.createStatement()) {
+                String sql = String.format(
+                        "CREATE TABLE %s(firstName TEXT, lastName TEXT, jsonid json, userid UUID)",
+                        tableName
+                );
+                log.info("Executing statement: {}", sql);
+                s.execute(sql);
+                c.commit();
+            }
+        }
+        log.info("Created table {} with UUID column", tableName);
+    }
+
+    private void startTask() {
+        task = new JdbcSinkTask();
+        task.start(props);
+    }
+
+    public void stopTask() {
+        if (task != null) {
+            task.stop();
+        }
+    }
+}

--- a/src/test/java/io/confluent/connect/jdbc/util/ColumnDefinitionBuilder.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/ColumnDefinitionBuilder.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.sql.JDBCType;
+
+public class ColumnDefinitionBuilder {
+
+    private String columnName;
+    private String typeName;
+    private int jdbcType = JDBCType.INTEGER.ordinal();
+    private int displaySize;
+    private int precision = 10;
+    private int scale = 0;
+    private boolean autoIncremented = false;
+    private boolean caseSensitive = false;
+    private boolean searchable = true;
+    private boolean currency = false;
+    private boolean signedNumbers = false;
+    private boolean isPrimaryKey = false;
+    private ColumnDefinition.Nullability nullability = ColumnDefinition.Nullability.NULL;
+    private ColumnDefinition.Mutability mutability = ColumnDefinition.Mutability.WRITABLE;
+    private String classNameForType;
+
+    public ColumnDefinitionBuilder(String name) {
+        this.columnName = name;
+    }
+
+    public ColumnDefinitionBuilder name(String columnName) {
+        this.columnName = columnName;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder type(String typeName, JDBCType jdbcType, Class<?> clazz) {
+        typeName(typeName);
+        jdbcType(jdbcType);
+        classNameForType(clazz != null ? clazz.getName() : null);
+        return this;
+    }
+
+    public ColumnDefinitionBuilder typeName(String typeName) {
+        this.typeName = typeName;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder jdbcType(JDBCType type) {
+        this.jdbcType = type.ordinal();
+        return this;
+    }
+
+    public ColumnDefinitionBuilder classNameForType(String classNameForType) {
+        this.classNameForType = classNameForType;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder displaySize(int size) {
+        this.displaySize = size;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder precision(int precision) {
+        this.precision = precision;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder scale(int scale) {
+        this.scale = scale;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder autoIncremented(boolean autoIncremented) {
+        this.autoIncremented = autoIncremented;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder caseSensitive(boolean caseSensitive) {
+        this.caseSensitive = caseSensitive;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder searchable(boolean searchable) {
+        this.searchable = searchable;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder currency(boolean currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder signedNumbers(boolean signedNumbers) {
+        this.signedNumbers = signedNumbers;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder primaryKey(boolean isPrimaryKey) {
+        this.isPrimaryKey = isPrimaryKey;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder nullable(boolean nullable) {
+        return nullability(
+                nullable ? ColumnDefinition.Nullability.NULL : ColumnDefinition.Nullability.NOT_NULL
+        );
+    }
+
+    public ColumnDefinitionBuilder nullability(ColumnDefinition.Nullability nullability) {
+        this.nullability = nullability;
+        return this;
+    }
+
+    public ColumnDefinitionBuilder mutability(ColumnDefinition.Mutability mutability) {
+        this.mutability = mutability;
+        return this;
+    }
+
+    public ColumnDefinition buildFor(TableId tableId) {
+        return new ColumnDefinition(
+                new ColumnId(tableId, columnName),
+                jdbcType,
+                typeName,
+                classNameForType,
+                nullability,
+                mutability,
+                precision,
+                scale,
+                signedNumbers,
+                displaySize,
+                autoIncremented,
+                caseSensitive,
+                searchable,
+                currency,
+                isPrimaryKey
+        );
+    }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/util/TableDefinitionBuilder.java
+++ b/src/test/java/io/confluent/connect/jdbc/util/TableDefinitionBuilder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class TableDefinitionBuilder {
+
+    private TableId tableId;
+    private Map<String, ColumnDefinitionBuilder> columnBuilders = new HashMap<>();
+
+    public TableDefinitionBuilder withTable(String tableName) {
+        tableId = new TableId(null, null, tableName);
+        return this;
+    }
+
+    public ColumnDefinitionBuilder withColumn(String columnName) {
+        return columnBuilders.computeIfAbsent(columnName, ColumnDefinitionBuilder::new);
+    }
+
+    public TableDefinition build() {
+        return new TableDefinition(
+                tableId,
+                columnBuilders.values().stream().map(b -> b.buildFor(tableId)).collect(Collectors.toList())
+        );
+    }
+
+}


### PR DESCRIPTION
Modify the methods on the `DatabaseDialect` interface used to supply the insert, update, and upsert expressions and create the prepared statements to use the table definition (and the corresponding the column definitions). The `GenericDatabaseDialect` class does not use these definitions, but the `PostgreSqlDatabaseDialect` class is modified to add the cast expression (e.g., `::uuid`) to the variable placeholder (e.g, `?`) if the column type matches one of the database types that requires casting, which in this case is either `uuid`, `json`, or `jsonb`.

Added an integration test to verify that string UUID and JSON literals can be inserted into a table with a `uuid` column and a `json` column.